### PR TITLE
fix: new span was not set as active

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -91,7 +91,7 @@ export class PubSubInstrumentation extends InstrumentationBase<typeof PubSub> {
               return orgNack.apply(msg);
             };
 
-            return context.with(ctx, () =>
+            return context.with(trace.setSpan(ctx, span), () =>
               safeExecuteInTheMiddle(
                 () => orgHandler.apply(this, args),
                 (err) => endSpan(span, err)


### PR DESCRIPTION
It seems like in the current implementation the new span started for the subscriber was not set as active. It made all the following spans attached to the wrong parent. 

We export our spans to jaeger UI. For the test, we create spans `one` and `two` inside the message handler. You can see that `topic.publishMessage` is a parent instead of `subscription.message`.
<img width="325" alt="Screenshot 2021-11-08 at 19 18 12" src="https://user-images.githubusercontent.com/1292425/140800094-cdc96c6d-4ffe-484f-bc47-80c4f64270da.png">

With the following fix, spans are assigned to the proper `subscription.message` parent span.
<img width="436" alt="Screenshot 2021-11-08 at 19 17 26" src="https://user-images.githubusercontent.com/1292425/140800687-cfc7867d-74c5-49c9-9318-31ef0d578e77.png">


